### PR TITLE
FreeBSD 12 support & compiler warning fixes for FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -472,7 +472,7 @@ case "$enable_sctp" in
 #include <sys/socket.h>
 ]])
 		case "$host" in
-		*-*-freebsd[[7-9]].* | *-*-freebsd1[[0-1]].* )
+		*-*-freebsd[[7-9]].* | *-*-freebsd1[[0-2]].* )
 			# FreeBSD 7.x and later SCTP support doesn't need -lsctp.
 			;;
 		*)
@@ -704,7 +704,7 @@ case "$enable_cpuutil" in
 			enable_cpuutil="kstat - auto"
 			NETCPU_SOURCE="kstat"
 			;;
-                     *-*-freebsd[[4-9]].* | *-*-freebsd1[[0-1]].* | *-*-netbsd[[1-9]].* )
+                     *-*-freebsd[[4-9]].* | *-*-freebsd1[[0-2]].* | *-*-netbsd[[1-9]].* )
 			use_cpuutil=true
 			AC_DEFINE([USE_SYSCTL],,[Use MumbleBSD's sysctl interface to measure CPU util.])
 			enable_cpuutil="sysctl - auto"

--- a/src/netcpu_sysctl.c
+++ b/src/netcpu_sysctl.c
@@ -8,6 +8,14 @@ char   netcpu_sysctl_id[]="\
 #include <stdio.h>
 #include <unistd.h>
 
+#if HAVE_STRING_H
+# include <string.h>
+#endif
+
+#if HAVE_STDLIB_H
+# include <stdlib.h>
+#endif
+
 #if HAVE_INTTYPES_H
 # include <inttypes.h>
 #else


### PR DESCRIPTION
Hi,

I sent the following patches to the netperf mailing list before I realized the project had moved to github.  The first patch allows compilation on FreeBSD 12, and the second fixes a few compiler warnings when compiling on FreeBSD.