### PR TITLE
Add ppc64le and aarch64* to config.guess

### DIFF
--- a/config.guess
+++ b/config.guess
@@ -814,6 +814,9 @@ EOF
     i*86:Minix:*:*)
 	echo ${UNAME_MACHINE}-pc-minix
 	exit ;;
+    aarch64*:Linux:*:*)
+	echo ${UNAME_MACHINE}-unknown-linux-gnu
+	exit ;;
     arm*:Linux:*:*)
 	echo ${UNAME_MACHINE}-unknown-linux-gnu
 	exit ;;
@@ -881,6 +884,9 @@ EOF
 	exit ;;
     ppc64:Linux:*:*)
 	echo powerpc64-unknown-linux-gnu
+	exit ;;
+    ppc64le:Linux:*:*)
+	echo powerpc64le-unknown-linux-gnu
 	exit ;;
     alpha:Linux:*:*)
 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in


### PR DESCRIPTION
The config.guess does not detect ppc64le, nor aarch64* machines, therefor machines can't be auto-detected. This adds such entries for generic-linux targets.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>