### PR TITLE
netserver: use mkstemp to create/open debug file

### DIFF
--- a/src/netserver.c
+++ b/src/netserver.c
@@ -254,20 +254,23 @@ open_debug_file()
   FILE *rd_null_fp;
 
   if (where != NULL) fflush(where);
-
-  snprintf(FileName,
-	   sizeof(FileName),
+  if (suppress_debug) {
+    FileName = NETPERF_NULL;
+    where = fopen(Filename, "w");
+  } else {
+    snprintf(FileName, sizeof(FileName),
 #if defined(WIN32)
-	   "%s\\%s_%d",
-	   getenv("TEMP"),
+	     "%s\\%s_XXXXXX", getenv("TEMP"),
 #else
-	   "%s_%d",
+	     "%s_XXXXXX",
 #endif
-	   DEBUG_LOG_FILE,
-	   getpid());
-  if ((where = fopen((suppress_debug) ? NETPERF_NULL : FileName,
-		     "w")) == NULL) {
-    perror("netserver: debug file");
+	     DEBUG_LOG_FILE);
+    where = mkstemp(FileName);
+  }
+
+  if (where == NULL) {
+    fprintf(stderr, "netserver: %s debug file : %s",
+	    FileName, strerror(errno));
     exit(1);
   }
 

--- a/src/netserver.c
+++ b/src/netserver.c
@@ -170,7 +170,8 @@ char	netserver_id[]="\
 #define   NETPERF_NULL       "/dev/null"
 #define   FILE_SEP       "/"
 #else
-#define   DEBUG_LOG_FILE_DIR "/tmp/"
+/* comply with FHS: http://www.pathname.com/fhs/pub/fhs-2.3.html */
+#define   DEBUG_LOG_FILE_DIR "/var/log/"
 #define   NETPERF_NULL       "/dev/null"
 #define   FILE_SEP       "/"
 #endif

--- a/src/netserver.c
+++ b/src/netserver.c
@@ -162,19 +162,22 @@ char	netserver_id[]="\
 
 #ifndef DEBUG_LOG_FILE_DIR
 #if defined(WIN32)
-#define   DEBUG_LOG_FILE_DIR ""
+#define   DEBUG_LOG_FILE_DIR getenv("TEMP")
 #define   NETPERF_NULL       "nul"
+#define   FILE_SEP       "\\"
 #elif defined(ANDROID)
 #define   DEBUG_LOG_FILE_DIR "/data/local/tmp/"
 #define   NETPERF_NULL       "/dev/null"
+#define   FILE_SEP       "/"
 #else
 #define   DEBUG_LOG_FILE_DIR "/tmp/"
 #define   NETPERF_NULL       "/dev/null"
+#define   FILE_SEP       "/"
 #endif
 #endif /* DEBUG_LOG_FILE_DIR */
 
 #ifndef DEBUG_LOG_FILE
-#define DEBUG_LOG_FILE DEBUG_LOG_FILE_DIR"netserver.debug"
+#define DEBUG_LOG_FILE "netserver.debug_XXXXXX"
 #endif
 
 #if !defined(PATH_MAX)
@@ -255,13 +258,8 @@ open_debug_file()
     FileName = NETPERF_NULL;
     where = fopen(Filename, "w");
   } else {
-    snprintf(FileName, sizeof(FileName),
-#if defined(WIN32)
-	     "%s\\%s_XXXXXX", getenv("TEMP"),
-#else
-	     "%s_XXXXXX",
-#endif
-	     DEBUG_LOG_FILE);
+    snprintf(FileName, sizeof(FileName), "%s" FILE_SEP "%s",
+             DEBUG_LOG_FILE_DIR, DEBUG_LOG_FILE);
     where = mkstemp(FileName);
   }
 

--- a/src/netserver.c
+++ b/src/netserver.c
@@ -162,11 +162,14 @@ char	netserver_id[]="\
 
 #ifndef DEBUG_LOG_FILE_DIR
 #if defined(WIN32)
-#define DEBUG_LOG_FILE_DIR ""
+#define   DEBUG_LOG_FILE_DIR ""
+#define   NETPERF_NULL       "nul"
 #elif defined(ANDROID)
-#define DEBUG_LOG_FILE_DIR "/data/local/tmp/"
+#define   DEBUG_LOG_FILE_DIR "/data/local/tmp/"
+#define   NETPERF_NULL       "/dev/null"
 #else
-#define DEBUG_LOG_FILE_DIR "/tmp/"
+#define   DEBUG_LOG_FILE_DIR "/tmp/"
+#define   NETPERF_NULL       "/dev/null"
 #endif
 #endif /* DEBUG_LOG_FILE_DIR */
 
@@ -245,12 +248,6 @@ unlink_empty_debug_file() {
 void
 open_debug_file()
 {
-#if !defined WIN32
-#define NETPERF_NULL "/dev/null"
-#else
-#define NETPERF_NULL "nul"
-#endif
-
   FILE *rd_null_fp;
 
   if (where != NULL) fflush(where);


### PR DESCRIPTION
This is another attempt to address the primary issue:
    https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=413658

similar to the original patch proposed:
    https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=413658;filename=CVE-2007-1444.patch;msg=35