### PR TITLE
Resolve Build Errors

### DIFF
--- a/src/netserver.c
+++ b/src/netserver.c
@@ -256,8 +256,8 @@ open_debug_file()
 
   if (where != NULL) fflush(where);
   if (suppress_debug) {
-    FileName = NETPERF_NULL;
-    where = fopen(Filename, "w");
+    strcpy(FileName, NETPERF_NULL);
+    where = fopen(FileName, "w");
   } else {
     snprintf(FileName, sizeof(FileName), "%s" FILE_SEP "%s",
              DEBUG_LOG_FILE_DIR, DEBUG_LOG_FILE);


### PR DESCRIPTION
This pull handles the error during netperf build. The errors are given below.
```
netserver.c:259:14: error: assignment to expression with array type
     FileName = NETPERF_NULL;
              ^
netserver.c:260:19: error: ‘Filename’ undeclared (first use in this function)
     where = fopen(Filename, "w");
```