### PR TITLE
netserver: fix mkstemp usage

### DIFF
--- a/src/netserver.c
+++ b/src/netserver.c
@@ -259,9 +259,15 @@ open_debug_file()
     strncpy(FileName, NETPERF_NULL, sizeof(FileName));
     where = fopen(FileName, "w");
   } else {
+    int fd;
     snprintf(FileName, sizeof(FileName), "%s" FILE_SEP "%s",
              DEBUG_LOG_FILE_DIR, DEBUG_LOG_FILE);
-    where = mkstemp(FileName);
+    fd = mkstemp(FileName);
+    if (fd < 0) {
+      fprintf(stderr, "netserver: creating debug file %s: %s\n", FileName, strerror(errno));
+      exit(1);
+    }
+    where = fdopen(fd, "w");
   }
 
   if (where == NULL) {


### PR DESCRIPTION
netserver segfaults on start because mkstemp() returns an file descriptor, not a file pointer. Use fdopen() to convert the file descriptor to a file pointer.

I see there's still some debate around whether using mkstemp is the way to go, but netserver doesn't start at all because of this issue.

Fixes: PR #10 @grundlerchromium 
