### PR TITLE
netserver: suppress debug log by default

### DIFF
--- a/src/netserver.c
+++ b/src/netserver.c
@@ -204,7 +204,7 @@ int      daemon_parent = 0;
 int      not_inetd;
 int      want_daemonize;
 int      spawn_on_accept;
-int      suppress_debug = 0;
+int      suppress_debug = 1;
 
 extern	char	*optarg;
 extern	int	optind, opterr;


### PR DESCRIPTION
The file is hardly used and now that it is being saved on /var/log by
default, netserver may fail to start as a normal user.

So simply suppress it by default. One can enable it again just by
issuing at least one '-d' command line option.

Closes: #19 

Signed-off-by: Marcelo Ricardo Leitner <marcelo.leitner@gmail.com>