### PR TITLE
netlib: processor_affinity conflicts in solaris

### DIFF
--- a/src/netlib.c
+++ b/src/netlib.c
@@ -2270,7 +2270,7 @@ shutdown_control()
   2004/12/13 */
 
 void
-bind_to_specific_processor(int processor_affinity, int use_cpu_map)
+bind_to_specific_processor(int use_cpu_affinity, int use_cpu_map)
 {
 
   int mapped_affinity;
@@ -2281,10 +2281,10 @@ bind_to_specific_processor(int processor_affinity, int use_cpu_map)
      a suitable CPU id even when the space is not contiguous and
      starting from zero */
   if (use_cpu_map) {
-    mapped_affinity = lib_cpu_map[processor_affinity];
+    mapped_affinity = lib_cpu_map[use_cpu_affinity];
   }
   else {
-    mapped_affinity = processor_affinity;
+    mapped_affinity = use_cpu_affinity;
   }
 
 #ifdef HAVE_MPCTL
@@ -2377,7 +2377,7 @@ bind_to_specific_processor(int processor_affinity, int use_cpu_map)
     if ((mapped_affinity < 0) ||
 	(mapped_affinity > MAXIMUM_PROCESSORS)) {
       fprintf(where,
-	      "Invalid processor_affinity specified: %d\n", mapped_affinity);      fflush(where);
+	      "Invalid use_cpu_affinity specified: %d\n", mapped_affinity);      fflush(where);
       return;
     }
 

--- a/src/netlib.h
+++ b/src/netlib.h
@@ -618,7 +618,7 @@ extern  double  calc_thruput_omni(double units_received);
 extern  double  calc_thruput_interval_omni(double units_received,double elapsed);
 extern  float   calibrate_local_cpu(float local_cpu_rate);
 extern  float   calibrate_remote_cpu();
-extern  void    bind_to_specific_processor(int processor_affinity,int use_cpu_map);
+extern  void    bind_to_specific_processor(int use_cpu_affinity,int use_cpu_map);
 extern int      set_nonblock (SOCKET sock);
 extern char     *find_egress_interface(struct sockaddr *source, struct sockaddr *dest);
 extern char     *find_interface_slot(char *interface_name);


### PR DESCRIPTION
Solaris has a syscall with the same name:
   https://docs.oracle.com/cd/E88353_01/html/E37841/processor-affinity-2.html

This change renames the function parameter to use_cpu_affinity to match
the use_cpu_map parameter.

---
Attempting to address issue #18 . I tested this with PR #21 and PR #22 . Also doesn't add any new warnings on linux.

I don't have access to Solaris (nor do I want it) but expect this should allow netperf to build on Solaris (which is a prerequisite to someone else posting netperf results for Solaris - just in case anyone cares.)