### PR TITLE
Small fixes to transmit pacing rate.

### DIFF
--- a/src/nettest_bsd.c
+++ b/src/nettest_bsd.c
@@ -405,6 +405,7 @@ TCP/UDP BSD Sockets Test Options:\n\
     -N                Use the connected socket for UDP remotely\n\
     -p min[,max]      Set the min/max port numbers for TCP_CRR, TCP_TRR\n\
     -P local[,remote] Set the local/remote port for the data socket\n\
+    -q rate           Transmit pacing rate\n\
     -r req,[rsp]      Set request/response sizes (TCP_RR, UDP_RR)\n\
     -s send[,recv]    Set local socket send/recv buffer sizes\n\
     -S send[,recv]    Set remote socket send/recv buffer sizes\n\
@@ -13153,7 +13154,7 @@ scan_sockets_args(int argc, char *argv[])
 
 {
 
-#define SOCKETS_ARGS "aAb:CDnNhH:L:m:M:p:P:r:R:s:S:T:Vw:W:z46"
+#define SOCKETS_ARGS "aAb:CDnNhH:L:m:M:p:P:q:r:R:s:S:T:Vw:W:z46"
 
   extern char	*optarg;	  /* pointer to option string	*/
 
@@ -13332,6 +13333,10 @@ scan_sockets_args(int argc, char *argv[])
 	strncpy(local_data_port,arg1,sizeof(local_data_port));
       if (arg2[0])
 	strncpy(remote_data_port,arg2,sizeof(remote_data_port));
+      break;
+    case 'q':
+      /* set the local socket pacing rate */
+      pacing_rate = convert(optarg);
       break;
     case 't':
       /* set the test name */

--- a/src/nettest_omni.c
+++ b/src/nettest_omni.c
@@ -7108,6 +7108,7 @@ OMNI and Migrated BSD Sockets Test Options:\n\
                       Use filename of '?' to get the list of choices\n\
     -p min[,max]      Set the min/max port numbers for TCP_CRR, TCP_TRR\n\
     -P local[,remote] Set the local/remote port for the data socket\n\
+    -q rate           Transmit pacing rate\n\
     -r req,[rsp]      Set request/response sizes (TCP_RR, UDP_RR)\n\
     -R 0/1            Allow routing of traffic on data connection.\n\
                       Default: 0 (off) for UDP_STREAM, 1 (on) otherwise\n\
@@ -7478,7 +7479,7 @@ scan_omni_args(int argc, char *argv[])
       break;
     case 'q':
       /* set the local socket pacing rate */
-      pacing_rate = atoi(optarg);
+      pacing_rate = convert(optarg);
       break;
     case 'r':
       /* set the request/response sizes. setting request/response


### PR DESCRIPTION
These two small changes let users use unit suffixes ('M', etc.) to set the pacing rate in addition to bare numbers and also support setting the rate for the non-OMNI sockets tests.