### PR TITLE
nettest_omni: Remove duplicate variable definitions

### DIFF
--- a/src/nettest_omni.c
+++ b/src/nettest_omni.c
@@ -458,14 +458,6 @@ static int client_port_max = 65535;
 
  /* different options for the sockets				*/
 
-int
-  loc_nodelay,		/* don't/do use NODELAY	locally		*/
-  rem_nodelay,		/* don't/do use NODELAY remotely	*/
-  loc_sndavoid,		/* avoid send copies locally		*/
-  loc_rcvavoid,		/* avoid recv copies locally		*/
-  rem_sndavoid,		/* avoid send copies remotely		*/
-  rem_rcvavoid; 	/* avoid recv_copies remotely		*/
-
 extern int
   loc_tcpcork,
   rem_tcpcork,


### PR DESCRIPTION
These defines are already defined in nettest_bsd.c and exported by
nettest_bsd.h this should fix build with -fno-common

Signed-off-by: Khem Raj <raj.khem@gmail.com>