### PR TITLE
src/nettest_omni.c: fix compilation with GCC10

### DIFF
--- a/src/nettest_omni.c
+++ b/src/nettest_omni.c
@@ -458,14 +458,6 @@ static int client_port_max = 65535;
 
  /* different options for the sockets				*/
 
-int
-  loc_nodelay,		/* don't/do use NODELAY	locally		*/
-  rem_nodelay,		/* don't/do use NODELAY remotely	*/
-  loc_sndavoid,		/* avoid send copies locally		*/
-  loc_rcvavoid,		/* avoid recv copies locally		*/
-  rem_sndavoid,		/* avoid send copies remotely		*/
-  rem_rcvavoid; 	/* avoid recv_copies remotely		*/
-
 extern int
   loc_tcpcork,
   rem_tcpcork,


### PR DESCRIPTION
GCC10 defaults to -fno-common, which breaks compilation when there are
multiple definitions of implicit "extern" variables. Remove the extra
definitions.

Fix #42

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
[Retrieved from:
https://github.com/openwrt/packages/blob/master/net/netperf/patches/010-gcc10_multiple_definition_fix.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>