### PR TITLE
netserver: do not chmod("/dev/null", 0644) when suppress_debug==1

### DIFF
--- a/src/netserver.c
+++ b/src/netserver.c
@@ -260,7 +260,10 @@ open_debug_file()
 
 #if !defined(WIN32)
 
-  chmod(FileName,0644);
+  /* Only chmod() if FileName != "/dev/null" */
+  if (strcmp(FileName, NETPERF_NULL)) {
+    chmod(FileName, 0644);
+  }
 
   /* redirect stdin to "/dev/null" */
   rd_null_fp = fopen(NETPERF_NULL,"r");


### PR DESCRIPTION
When running as root, chmod("/dev/null", 0644) will break most Unix-like
systems as "/dev/null" can't be open for write by non-root users anymore.

Before the fix:
root@linux# strace -f -e chmod ./netserver
Starting netserver with host 'IN(6)ADDR_ANY' port '12865' and family AF_UNSPEC
strace: Process 976220 attached
[pid 976219] +++ exited with 0 +++
chmod("/dev/null", 0644)                = 0

Fixes: 5380b1f5 ("netserver: use mkstemp to create/open debug file")