### PR TITLE
Fix build failures on macOS in netcpu_osx.c

### DIFF
--- a/src/netcpu_osx.c
+++ b/src/netcpu_osx.c
@@ -93,7 +93,7 @@ cpu_util_init(void)
 void
 cpu_util_terminate(void)
 {
-  mach_port_deallocate(lib_host_port);
+  mach_port_deallocate(mach_task_self(), lib_host_port);
   return;
 }
 

--- a/src/netcpu_osx.c
+++ b/src/netcpu_osx.c
@@ -71,7 +71,7 @@ char   netcpu_sysctl_id[]="\
    SnowLeopard (10.6) happy, we hope it does not anger previous
    versions */
 #include <mach/mach_host.h>
-/* #include <mach/mach_port.h> */
+#include <mach/mach_port.h>
 
 #include "netsh.h"
 #include "netlib.h"


### PR DESCRIPTION
netperf 2.7.0 fails to build on macOS 10.15 or later with Xcode 12 or later because as of Xcode 12 implicit declaration of function is an error. (The compiler behaves by default as if `-Werror=implicit-function-declaration` has been specified.) I originally [reported this to MacPorts here](https://trac.macports.org/ticket/62219).

After applying 0b0cbbef75021134c83be0c3dd21878467e11144 to fix implicit declarations of `read` and `close`, the remaining error is:

```
netcpu_osx.c:73:3: error: implicit declaration of function 'mach_port_deallocate' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```

After fixing that by including the right header (or uncommenting the inclusion of the right header), the error is then:

```
netcpu_osx.c:73:37: error: too few arguments to function call, expected 2, have 1
```

I don't know whether the [signature of mach_port_deallocate](https://developer.apple.com/documentation/kernel/1578777-mach_port_deallocate) changed since this code was added or whether the code was always wrong. Mach functions are hard to find documentation for, so much so that I don't know what the second (or, it turns out, first) argument should be, but every code sample I found that used this function used `mach_task_self()` as the first argument, so that's what I used here. It at least compiles now.