### PR TITLE
configure.ac: use AC_USE_SYSTEM_EXTENSIONS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,8 @@ AC_HAVE_LIBRARY(m)
 AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 
+AC_USE_SYSTEM_EXTENSIONS
+
 # lets keep this in some semblence of alphabetical order
 AC_CHECK_HEADERS([arpa/inet.h endian.h errno.h fcntl.h ifaddrs.h limits.h linux/tcp.h linux/socket.h malloc.h netdb.h netinet/in.h netinet/sctp.h sched.h signal.h stdlib.h string.h strings.h syscall.h sys/ioctl.h sys/mman.h sys/param.h sys/socket.h sys/stat.h sys/time.h sys/wait.h sys/ipc.h sys/sockio.h sys/sysinfo.h sys/wait.h stdlib.h unistd.h netinet/in_systm.h netinet/ip.h sys/sendfile.h])
 


### PR DESCRIPTION
functions like splice(2) and sched_setaffinity(2), used in netperf, require _GNU_SOURCE to be declared. without it, we see warnings about missing definitions. once upon a time, AC_GNU_SOURCE would have pulled this in where appropriate, but that's just an alias these days for AC_USE_SYSTEM_EXTENSIONS. with this added, we no longer see the warnings on linux.