### PR TITLE
sctp: fix in sctp_process_event and send_sctp_stream

### DIFF
--- a/src/nettest_sctp.c
+++ b/src/nettest_sctp.c
@@ -259,7 +259,7 @@ sctp_process_event( int socket, void *buf )
 	    fflush(where);
 	}
 	sac = &snp->sn_assoc_change;
-	switch (sac->sac_type) {
+	switch (sac->sac_state) {
 	    case SCTP_COMM_UP:
 		if (debug) {
 		    fprintf(where, "  SCTP_COMM_UP\n");
@@ -292,6 +292,7 @@ sctp_process_event( int socket, void *buf )
 		return SCTP_CLOSE;
 		break;
 	}
+	break;
 
     case SCTP_SEND_FAILED:
 	if (debug) {

--- a/src/nettest_sctp.c
+++ b/src/nettest_sctp.c
@@ -573,7 +573,7 @@ Size (bytes)\n\
     sctp_stream_request->dirty_count    =       rem_dirty_count;
     sctp_stream_request->clean_count    =       rem_clean_count;
 #endif /* DIRTY */
-    sctp_stream_request->port		=	htonl(atoi(remote_data_port));
+    sctp_stream_request->port		=	atoi(remote_data_port);
     sctp_stream_request->ipfamily	=	af_to_nf(remote_res->ai_family);
     sctp_stream_request->non_blocking   =	non_block;
 


### PR DESCRIPTION
This patchset fixes SCTP_ASSOC_CHANGE event process and "-- -P" parameter for SCTP_STREAM.