### PR TITLE
Fix too many arguments error occurring in gcc-15

### DIFF
--- a/src/netlib.h
+++ b/src/netlib.h
@@ -564,6 +564,7 @@ extern void   demo_interval_final();
 #endif
 #endif
 
+#include "hist.h"
 extern  void    netlib_init();
 extern  int     netlib_get_page_size();
 extern  void    install_signal_catchers();
@@ -646,9 +647,9 @@ extern char     *find_interface_slot(char *interface_name);
 extern void     find_interface_ids(char *interface_name, int *vendor, int *device, int *sub_vend, int *sub_dev);
 extern void     find_driver_info(char *ifname, char *driver, char *version, char *firmware, char *bus, int len);
 extern void     find_system_info(char **system_model, char **cpu_model, int *cpu_frequency);
-extern int      HIST_get_percentile();
-extern void     HIST_get_stats();
-extern void     HIST_purge();
+extern int      HIST_get_percentile(HIST h, const double percentile);
+extern void     HIST_get_stats(HIST h, int *min, int *max, double *mean, double *stddev);
+extern void     HIST_purge(HIST h);
 extern void     find_security_info(int *enabled, int *type, char **specific);
 extern void     demo_first_timestamp();
 extern void     demo_reset();
@@ -676,7 +677,7 @@ extern  void    catcher(int, siginfo_t *,void *);
 #else
 extern  void    catcher(int);
 #endif /* __hpux */
-extern  struct ring_elt *allocate_buffer_ring();
+extern  struct ring_elt *allocate_buffer_ring(int recv_width, int recv_size, int local_recv_align, int local_recv_offset);
 extern void access_buffer(char *buffer_ptr,
 			  int length,
 			  int dirty_count,
@@ -687,7 +688,7 @@ extern  struct ring_elt *allocate_exs_buffer_ring();
 #endif /* HAVE_ICSC_EXS */
 
 #ifdef HAVE_SENDFILE
-extern  struct ring_elt *alloc_sendfile_buf_ring();
+extern  struct ring_elt *alloc_sendfile_buf_ring(int send_width, int send_size, int local_send_align, int local_send_offset);
 extern  int netperf_sendfile(SOCKET send_socket, struct ring_elt *send_ring);
 #endif /* HAVE_SENDFILE */
 


### PR DESCRIPTION
* See more details in http://errors.yoctoproject.org/Errors/Details/851803/ 

```
../../git/src/nettest_bsd.c:4497:19: error: too many 
arguments to function 'alloc_sendfile_buf_ring'; expected 0, have 4
 4497 |       send_ring = alloc_sendfile_buf_ring(send_width,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
In file included from ../../git/src/nettest_bsd.c:175:
../../git/src/netlib.h:690:26: note: declared here
  690 | extern  struct ring_elt *alloc_sendfile_buf_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~~~~
In file included from ../../git/src/nettest_omni.c:184:
../../git/src/hist.h:135:6: error: conflicting types for 'HIST_purge'; have 'void(struct histogram_struct *)'
  135 | void HIST_purge(HIST h);
      |      ^~~~~~~~~~
In file included from ../../git/src/nettest_omni.c:166:
../../git/src/netlib.h:651:17: note: previous declaration of 'HIST_purge' with type 'void(void)'
  651 | extern void     HIST_purge();
      |                 ^~~~~~~~~~
../../git/src/nettest_bsd.c: In function 'recv_tcp_stream':
../../git/src/nettest_bsd.c:5197:15: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 5197 |   recv_ring = allocate_buffer_ring(recv_width,
      |               ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
../../git/src/nettest_bsd.c: In function 'recv_tcp_maerts':
../../git/src/nettest_bsd.c:5617:15: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 5617 |   send_ring = allocate_buffer_ring(send_width,
      |               ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
../../git/src/nettest_bsd.c: In function 'recv_udp_stream':
../../git/src/nettest_bsd.c:7345:15: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 7345 |   recv_ring = allocate_buffer_ring(recv_width,
      |               ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
../../git/src/nettest_bsd.c: In function 'recv_udp_rr':
../../git/src/nettest_bsd.c:8360:15: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 8360 |   recv_ring = allocate_buffer_ring(recv_width,
      |               ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
../../git/src/nettest_bsd.c:8365:15: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 8365 |   send_ring = allocate_buffer_ring(send_width,
      |               ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
../../git/src/nettest_bsd.c: In function 'recv_tcp_rr':
../../git/src/nettest_bsd.c:8677:15: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 8677 |   send_ring = allocate_buffer_ring(send_width,
      |               ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
../../git/src/nettest_bsd.c:8682:15: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 8682 |   recv_ring = allocate_buffer_ring(recv_width,
      |               ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
../../git/src/nettest_omni.c: In function 'send_omni_inner':
../../git/src/nettest_omni.c:4044:21: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 4044 |         send_ring = allocate_buffer_ring(send_width,
      |                     ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
../../git/src/nettest_omni.c:4086:21: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 4086 |         recv_ring = allocate_buffer_ring(recv_width,
      |                     ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
../../git/src/nettest_omni.c:5050:5: error: too many arguments to function 'HIST_get_stats'; expected 0, have 5
 5050 |     HIST_get_stats(time_hist,
      |     ^~~~~~~~~~~~~~ ~~~~~~~~~
../../git/src/netlib.h:650:17: note: declared here
  650 | extern void     HIST_get_stats();
      |                 ^~~~~~~~~~~~~~
../../git/src/nettest_omni.c:5055:19: error: too many arguments to function 'HIST_get_percentile'; expected 0, have 2
 5055 |     p50_latency = HIST_get_percentile(time_hist, 0.50);
      |                   ^~~~~~~~~~~~~~~~~~~ ~~~~~~~~~
../../git/src/netlib.h:649:17: note: declared here
  649 | extern int      HIST_get_percentile();
      |                 ^~~~~~~~~~~~~~~~~~~
../../git/src/nettest_omni.c:5056:19: error: too many arguments to function 'HIST_get_percentile'; expected 0, have 2
 5056 |     p90_latency = HIST_get_percentile(time_hist, 0.90);
      |                   ^~~~~~~~~~~~~~~~~~~ ~~~~~~~~~
../../git/src/netlib.h:649:17: note: declared here
  649 | extern int      HIST_get_percentile();
      |                 ^~~~~~~~~~~~~~~~~~~
../../git/src/nettest_omni.c:5057:19: error: too many arguments to function 'HIST_get_percentile'; expected 0, have 2
 5057 |     p99_latency = HIST_get_percentile(time_hist, 0.99);
      |                   ^~~~~~~~~~~~~~~~~~~ ~~~~~~~~~
../../git/src/netlib.h:649:17: note: declared here
  649 | extern int      HIST_get_percentile();
      |                 ^~~~~~~~~~~~~~~~~~~
../../git/src/nettest_omni.c: In function 'recv_omni':
../../git/src/nettest_omni.c:5354:17: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 5354 |     send_ring = allocate_buffer_ring(send_width,
      |                 ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
../../git/src/nettest_omni.c:5396:17: error: too many arguments to function 'allocate_buffer_ring'; expected 0, have 4
 5396 |     recv_ring = allocate_buffer_ring(recv_width,
      |                 ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
../../git/src/netlib.h:679:26: note: declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
      |                          ^~~~~~~~~~~~~~~~~~~~
```