### PR TITLE
Fix multiple definition

### DIFF
--- a/src/nettest_omni.c
+++ b/src/nettest_omni.c
@@ -485,15 +485,13 @@ static int client_port_max = 65535;
 
  /* different options for the sockets				*/
 
-int
+extern int
   loc_nodelay,		/* don't/do use NODELAY	locally		*/
   rem_nodelay,		/* don't/do use NODELAY remotely	*/
   loc_sndavoid,		/* avoid send copies locally		*/
   loc_rcvavoid,		/* avoid recv copies locally		*/
   rem_sndavoid,		/* avoid send copies remotely		*/
-  rem_rcvavoid; 	/* avoid recv_copies remotely		*/
-
-extern int
+  rem_rcvavoid, 	/* avoid recv_copies remotely		*/
   loc_tcpcork,
   rem_tcpcork,
   local_connected,


### PR DESCRIPTION
When I use the source code to build the netperf 2.7.0 version, I encounter the following problems：
![7d6519701857f6333cb08e60c45e6ec](https://github.com/user-attachments/assets/4cf19d05-a0b2-48bd-91c9-44793911457f)


You can reproduce the problem by running the following command：
`wget https://github.com/HewlettPackard/netperf/archive/refs/tags/netperf-2.7.0.tar.gz`
`tar -zxvf netperf-2.7.0.tar.gz`
`cd netperf-netperf-2.7.0`
`./configure --build=aarch64-unknown-linux-gnu`
`make -j $(nproc)`