### PR TITLE
Update README links after github migration

### DIFF
--- a/README
+++ b/README
@@ -5,9 +5,9 @@ BE SURE TO READ THE MANUAL. EVEN THOUGH IT MAY BE OUTDATED.
 This is a brief readme file for the netperf TCP/UDP/sockets/etc
 performance benchmark. This is here mostly as a boot-strap. The real
 information is in the manual, which can be found in netperf.ps and
-online from http://www.netperf.org/netperf/NetperfPage.html. The
+online from https://hewlettpackard.github.io/netperf/. The
 sources, and a limited number of binaries, can be found from
-ftp://ftp.cup.hp.com/dist/networking/benchmarks/netperf/ .
+https://github.com/HewlettPackard/netperf.
 
 BE SURE TO READ THE MANUAL. EVEN THOUGH IT MAY BE OUTDATED.
 
@@ -17,12 +17,15 @@ using the MIT license.
 
 Feel free to report netperf results in public forums, but please be
 excruciatingly complete in your description of the test envorinment.
-The old netperf database at:
+The old netperf database previously available at:
 
   http://www.netperf.org/netperf/NetperfPage.html
 
-is no more - or rather the utilities for accessing it no longer run.
-The data is still present in the tree, albeit _VERY_ old now.
+is no more - as the utilities for accessing it no longer run. The
+data is no longer present after the github migration. Historical
+data can be retrieved from the Wayback Machine at:
+
+  https://web.archive.org/web/20170424143612/http://www.netperf.org/netperf/NetperfNumbers.html
 
 There is an Internet mailing list devoted to netperf. It is called
 netperf-talk and it is hosted on netperf.org. Subscription requests

--- a/README
+++ b/README
@@ -24,12 +24,6 @@ The old netperf database at:
 is no more - or rather the utilities for accessing it no longer run.
 The data is still present in the tree, albeit _VERY_ old now.
 
-There is an Internet mailing list devoted to netperf. It is called
-netperf-talk and it is hosted on netperf.org. Subscription requests
-should go to netperf-talk-request@netperf.org.
-
-Please DO NOT SEND subscription requests to netperf-talk!
-
 If you run into severe difficulties, or are just feeling chatty,
 please feel free to drop some email to me - Rick Jones
 <rick.jones2@hp.com>. Be sure to include a meaningful subject lines.

--- a/README
+++ b/README
@@ -17,15 +17,12 @@ using the MIT license.
 
 Feel free to report netperf results in public forums, but please be
 excruciatingly complete in your description of the test envorinment.
-The old netperf database previously available at:
+The old netperf database at:
 
-  http://www.netperf.org/netperf/NetperfPage.html
+  https://github.com/HewlettPackard/netperf/tree/gh-pages/data
 
-is no more - as the utilities for accessing it no longer run. The
-data is no longer present after the github migration. Historical
-data can be retrieved from the Wayback Machine at:
-
-  https://web.archive.org/web/20170424143612/http://www.netperf.org/netperf/NetperfNumbers.html
+is no more - or rather the utilities for accessing it no longer run.
+The data is still present in the tree, albeit _VERY_ old now.
 
 There is an Internet mailing list devoted to netperf. It is called
 netperf-talk and it is hosted on netperf.org. Subscription requests


### PR DESCRIPTION
Updated links in the README to point to the newer github pages site.
Additionally, removed references to the mailing list, as I assume it is defunct.